### PR TITLE
Some responses to strong one club

### DIFF
--- a/Bidding/Bidding/RevealedInfo.cs
+++ b/Bidding/Bidding/RevealedInfo.cs
@@ -1,12 +1,13 @@
+using System.Collections.Generic;
+using Bidding.Common;
+
 namespace Bidding.Bidding
 {
     public class RevealedInfo
     {
         public Position Position { get; set; }
-        public int MinHCP { get; set; } = 0;
-        public int MaxHCP { get; set; } = 40;
-        public int MinTotalPoints { get; set; } = 0;
-        public int MaxTotalPoints { get; set; } = 40;
+        public IEnumerable<Range> HCP { get; set; }
+        public IEnumerable<Range> TotalPoints { get; set; }
         public int MinClubs { get; set; } = 0;
         public int MaxClubs { get; set; } = 13;
         public int MinDiamonds { get; set; } = 0;
@@ -15,5 +16,27 @@ namespace Bidding.Bidding
         public int MaxHearts { get; set; } = 13;
         public int MinSpades { get; set; } = 0;
         public int MaxSpades { get; set; } = 13;
+
+        public void MinSuit(Suit suit, int value) => Reflect($"Min{suit}s", value);
+        public void MaxSuit(Suit suit, int value) => Reflect($"Max{suit}s", value);
+        public void ExactSuit(Suit suit, int value)
+        {
+            Reflect($"Min{suit}s", value);
+            Reflect($"Max{suit}s", value);
+        }
+        public void MinAllSuits(int value) => ReflectAll("Min", value);
+        public void MaxAllSuits(int value) => ReflectAll("Max", value);
+
+        private void Reflect(string propertyName, int value) => typeof(RevealedInfo).GetProperty(propertyName).SetValue(this, value);
+        private void ReflectAll(string propertyPrefix, int value)
+        {
+            foreach (var p in typeof(RevealedInfo).GetProperties())
+            {
+                if (p.Name.StartsWith(propertyPrefix))
+                {
+                    p.SetValue(this, value);
+                }
+            }
+        }
     }
 }

--- a/Bidding/Bidding/Rules/ActiveResponseToStrongOneClub.cs
+++ b/Bidding/Bidding/Rules/ActiveResponseToStrongOneClub.cs
@@ -1,0 +1,39 @@
+// P.12
+using System.Collections.Generic;
+using Bidding.Common;
+
+namespace Bidding.Bidding.Rules
+{
+    public class ActiveResponseToStrongOneClub : IRule
+    {
+        private static readonly HashSet<Contract> _applicableContracts = new HashSet<Contract>(
+            new Contract[] {
+                new Contract(Level.One, Suit.Heart),
+                new Contract(Level.One, Suit.Spade),
+                new Contract(Level.Two, Suit.Club),
+                new Contract(Level.Two, Suit.Diamond)
+            });
+        private static readonly IEnumerable<Convention> _applicableConventions = new Convention[] { Convention.Precision };
+
+        public ISet<Contract> ApplicableContracts => _applicableContracts;
+        public IEnumerable<Convention> ApplicableConventions => _applicableConventions;
+        public bool IsForcing => false;
+
+        public RevealedInfo InformationRevealed(Bid bid, BidState state)
+        {
+            // HCP => 8-24, Suit => 5xyz
+            var info = new RevealedInfo { HCP = new List<Range>() { new Range { Min = 8, Max = 24 } } };
+            info.MinSuit(bid.Contract.Suit.Value, 5);
+            return info;
+        }
+
+        public bool MatchesConditions(Bid bid, BidState state)
+        {
+            if (state.BiddingHistory.ElementAtLast(2).Contract == new Contract(Level.One, Suit.Club))
+            {
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Bidding/Bidding/Rules/BalancedActiveResponseToStrongOneClub.cs
+++ b/Bidding/Bidding/Rules/BalancedActiveResponseToStrongOneClub.cs
@@ -1,0 +1,52 @@
+// P.13
+using System.Collections.Generic;
+using Bidding.Common;
+
+namespace Bidding.Bidding.Rules
+{
+    public class BalancedActiveResponseToStrongOneClub : IRule
+    {
+        private static readonly HashSet<Contract> _applicableContracts = new HashSet<Contract>(
+            new Contract[] {
+                new Contract(Level.One, null),
+                new Contract(Level.Two, null),
+            });
+        private static readonly IEnumerable<Convention> _applicableConventions = new Convention[] { Convention.Precision };
+
+        public ISet<Contract> ApplicableContracts => _applicableContracts;
+        public IEnumerable<Convention> ApplicableConventions => _applicableConventions;
+        public bool IsForcing => false;
+
+        public RevealedInfo InformationRevealed(Bid bid, BidState state)
+        {
+            // Suit => [1-4]{4}
+            // HCP =>
+            // 1NT: 8-13, 16-24
+            // 2NT: 14-15
+            var info = new RevealedInfo();
+            info.MaxAllSuits(4);
+            info.MinAllSuits(1);
+            if (bid.Contract.Level == Level.One)
+            {
+                info.HCP = new List<Range> {
+                    new Range { Min = 8, Max = 13 },
+                    new Range { Min = 16, Max = 24 }
+                };
+            }
+            else if (bid.Contract.Level == Level.Two)
+            {
+                info.HCP = new List<Range> { new Range { Min = 14, Max = 15 } };
+            }
+            return info;
+        }
+
+        public bool MatchesConditions(Bid bid, BidState state)
+        {
+            if (state.BiddingHistory.ElementAtLast(2).Contract == new Contract(Level.One, Suit.Club))
+            {
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Bidding/Bidding/Rules/IRule.cs
+++ b/Bidding/Bidding/Rules/IRule.cs
@@ -1,14 +1,15 @@
 using System.Collections.Generic;
 using Bidding.Common;
-using Bidding.Bidding;
 
 namespace Bidding.Bidding.Rules
 {
     public interface IRule
     {
-        IEnumerable<Convention> GetConventions();
-        ISet<Contract> GetApplicableContracts();
-        bool MatchesConditions(Bid bid, BidState state);
+        ISet<Contract> ApplicableContracts { get; }
+        IEnumerable<Convention> ApplicableConventions { get; }
+        bool IsForcing { get; }
+
         RevealedInfo InformationRevealed(Bid bid, BidState state);
+        bool MatchesConditions(Bid bid, BidState state);
     }
 }

--- a/Bidding/Bidding/Rules/PassiveResponseToStrongOneClub.cs
+++ b/Bidding/Bidding/Rules/PassiveResponseToStrongOneClub.cs
@@ -1,30 +1,36 @@
-// P.11
+// P.12
 using System.Collections.Generic;
 using Bidding.Common;
 
 namespace Bidding.Bidding.Rules
 {
-    public class StrongOneClub : IRule
+    public class PassiveResponseToStrongOneClub : IRule
     {
         private static readonly HashSet<Contract> _applicableContracts = new HashSet<Contract>(
             new Contract[] {
-                new Contract(Level.One, Suit.Club)
+                new Contract(Level.One, Suit.Diamond)
             });
         private static readonly IEnumerable<Convention> _applicableConventions = new Convention[] { Convention.Precision };
 
         public ISet<Contract> ApplicableContracts => _applicableContracts;
         public IEnumerable<Convention> ApplicableConventions => _applicableConventions;
-        public bool IsForcing => true;
+        public bool IsForcing => false;
 
         public RevealedInfo InformationRevealed(Bid bid, BidState state)
         {
-            // HCP => 16-40
-            return new RevealedInfo { HCP = new List<Range>() { new Range { Min = 16, Max = 40 } } };
+            return new RevealedInfo { HCP = new List<Range>() { new Range { Min = 0, Max = 7 } } };
         }
 
         public bool MatchesConditions(Bid bid, BidState state)
         {
-            return true;
+            if (bid.Contract == new Contract(Level.One, Suit.Diamond))
+            {
+                if (state.BiddingHistory.ElementAtLast(2).Contract == new Contract(Level.One, Suit.Club))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/Bidding/Bidding/Rules/SingletonActiveResponseToStrongOneClub.cs
+++ b/Bidding/Bidding/Rules/SingletonActiveResponseToStrongOneClub.cs
@@ -1,0 +1,46 @@
+// P.14
+using System.Collections.Generic;
+using System.Linq;
+using Bidding.Common;
+using EnumsNET;
+
+namespace Bidding.Bidding.Rules
+{
+    public class SingletonActiveResponseToStrongOneClub : IRule
+    {
+        private static readonly HashSet<Contract> _applicableContracts = new HashSet<Contract>(
+            new Contract[] {
+                new Contract(Level.Two, Suit.Heart),
+                new Contract(Level.Two, Suit.Spade),
+                new Contract(Level.Three, Suit.Club),
+                new Contract(Level.Three, Suit.Diamond)
+            });
+        private static readonly IEnumerable<Convention> _applicableConventions = new Convention[] { Convention.Precision };
+
+        public ISet<Contract> ApplicableContracts => _applicableContracts;
+        public IEnumerable<Convention> ApplicableConventions => _applicableConventions;
+        public bool IsForcing => false;
+
+        public RevealedInfo InformationRevealed(Bid bid, BidState state)
+        {
+            // HCP => 8-24, Suit => 4441
+            var info = new RevealedInfo { HCP = new List<Range>() { new Range { Min = 8, Max = 24 } } };
+            var singletonSuit = bid.Contract.Suit.Value.Next();
+            info.ExactSuit(singletonSuit, 1);
+            foreach (var suit in Enums.GetValues<Suit>().Where(s => s != singletonSuit))
+            {
+                info.ExactSuit(suit, 4);
+            }
+            return info;
+        }
+
+        public bool MatchesConditions(Bid bid, BidState state)
+        {
+            if (state.BiddingHistory.ElementAtLast(2).Contract == new Contract(Level.One, Suit.Club))
+            {
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Bidding/Common/Contract.cs
+++ b/Bidding/Common/Contract.cs
@@ -24,6 +24,8 @@ namespace Bidding.Common
 
         public static bool operator >(Contract c1, Contract c2) => c1.Order() > c2.Order();
         public static bool operator <(Contract c1, Contract c2) => c1.Order() < c2.Order();
+        public static bool operator ==(Contract c1, Contract c2) => c1.Order() == c2.Order();
+        public static bool operator !=(Contract c1, Contract c2) => c1.Order() != c2.Order();
 
         public bool IsGame()
         {

--- a/Bidding/Common/Extension.cs
+++ b/Bidding/Common/Extension.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bidding.Common
+{
+    public static class Extensions
+    {
+        public static T ElementAtLast<T>(this IEnumerable<T> source, int n)
+        {
+            return source.SkipLast(n - 1).Last();
+        }
+
+        public static Range Intersect(this Range source, Range other)
+        {
+            if (source.Min < other.Min)
+            {
+                return new Range { Min = other.Min, Max = Math.Min(source.Max, other.Max) };
+            }
+            if (source.Min > other.Min && source.Min < other.Max)
+            {
+                return new Range { Min = source.Min, Max = Math.Min(source.Max, other.Max) };
+            }
+            return null;
+        }
+
+        public static TEnum Previous<TEnum>(this TEnum src) where TEnum : struct
+        {
+            if (!typeof(TEnum).IsEnum)
+            {
+                throw new ArgumentException();
+            }
+
+            var enums = (TEnum[])Enum.GetValues(src.GetType());
+            var i = Array.IndexOf<TEnum>(enums, src);
+            return (i == 0) ? enums[enums.Length - 1] : enums[i - 1];
+        }
+
+        public static TEnum Next<TEnum>(this TEnum src) where TEnum : struct
+        {
+            if (!typeof(TEnum).IsEnum)
+            {
+                throw new ArgumentException();
+            }
+
+            var enums = (TEnum[])Enum.GetValues(src.GetType());
+            var i = Array.IndexOf<TEnum>(enums, src);
+            return (i == enums.Length - 1) ? enums[0] : enums[i + 1];
+        }
+    }
+}

--- a/Bidding/Common/Range.cs
+++ b/Bidding/Common/Range.cs
@@ -1,0 +1,8 @@
+namespace Bidding.Common
+{
+    public class Range
+    {
+        public int Min { get; set; }
+        public int Max { get; set; }
+    }
+}

--- a/Bidding/Framework/Bidding.cs
+++ b/Bidding/Framework/Bidding.cs
@@ -1,7 +1,7 @@
-using EnumsNET;
 using System.Collections.Generic;
 using System.Linq;
 using Bidding.Common;
+using EnumsNET;
 
 namespace Bidding.Framework
 {


### PR DESCRIPTION
- some extension methods
- change HCP and TotalPoints of `RevealedInfo` to `IEnumerable<Range>`
- add update methods of `RevealedInfo` using reflection
- change `ApplicableContracts`, `ApplicableConventions` of `IRule` to property
- add property `IsForcing` to `IRule`
- Remove basic check in `MatchesConditions` of `IRule`. Don't think we need to check if bid is in applicable contracts in `MatchesConditions`

### Porting
- StrongOneClub
- PassiveResponseToStrongOneClub
- ActiveResponseToStrongOneClub
- BalancedActiveResponseToStrongOneClub
- SingletonActiveResponseToStrongOneClub
